### PR TITLE
fix(ShaderView): resize drawing buffer on layout change (rotation)

### DIFF
--- a/src/components/ShaderView/index.tsx
+++ b/src/components/ShaderView/index.tsx
@@ -29,7 +29,7 @@ export default function ShaderView({
   style,
   ...viewProps
 }: ShaderViewProps) {
-  const { canvasRef, runtime, resources } = useWGPUSetup();
+  const { canvasRef, runtime, resources, onCanvasLayout } = useWGPUSetup();
 
   const propsSync = useRef(
     createSynchronizable<Float64Array>(new Float64Array(SYNC_SIZE))
@@ -262,6 +262,10 @@ export default function ShaderView({
       transparent={transparent}
       style={[styles.canvas, style]}
       {...viewProps}
+      onLayout={(event) => {
+        onCanvasLayout(event);
+        viewProps.onLayout?.(event);
+      }}
     />
   );
 }

--- a/src/hooks/useWGPUSetup.tsx
+++ b/src/hooks/useWGPUSetup.tsx
@@ -1,10 +1,10 @@
-import { PixelRatio } from 'react-native';
+import { PixelRatio, type LayoutChangeEvent } from 'react-native';
 import {
   useCanvasRef,
   type CanvasRef,
   type RNCanvasContext,
 } from 'react-native-webgpu';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { WorkletRuntime } from 'react-native-worklets';
 import { BackgroundRuntime } from '../utils/backgroundRuntime';
 
@@ -14,16 +14,30 @@ type GPUResources = {
   presentationFormat: GPUTextureFormat;
 };
 
+type CanvasWithSize = RNCanvasContext['canvas'] & {
+  width: number;
+  height: number;
+};
+
 type WGPUSetupResult = {
   canvasRef: React.RefObject<CanvasRef>;
   runtime: WorkletRuntime;
   resources: GPUResources | null;
+  /** Wire to `<Canvas onLayout>` so the surface resizes on rotation/layout change. */
+  onCanvasLayout: (event: LayoutChangeEvent) => void;
 };
 
 export function useWGPUSetup(): WGPUSetupResult {
   const canvasRef = useCanvasRef();
   const [resources, setResources] = useState<GPUResources | null>(null);
   const runtime = BackgroundRuntime;
+
+  // Physical-pixel size the surface is currently configured for. Used to drive
+  // resize (and to skip redundant reconfigures when the layout pass reports the
+  // same size).
+  const configuredSizeRef = useRef<{ width: number; height: number } | null>(
+    null
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -40,13 +54,12 @@ export function useWGPUSetup(): WGPUSetupResult {
       }
 
       const context = canvasRef.current!.getContext('webgpu')!;
-      const canvas = context.canvas as typeof context.canvas & {
-        width: number;
-        height: number;
-      };
+      const canvas = context.canvas as CanvasWithSize;
       const dpr = PixelRatio.get();
-      canvas.width = canvas.width * dpr;
-      canvas.height = canvas.height * dpr;
+      const width = Math.max(1, Math.round(canvas.width * dpr));
+      const height = Math.max(1, Math.round(canvas.height * dpr));
+      canvas.width = width;
+      canvas.height = height;
 
       const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
       context.configure({
@@ -54,6 +67,7 @@ export function useWGPUSetup(): WGPUSetupResult {
         format: presentationFormat,
         alphaMode: 'premultiplied',
       });
+      configuredSizeRef.current = { width, height };
 
       if (!cancelled) {
         setResources({ device, context, presentationFormat });
@@ -66,5 +80,39 @@ export function useWGPUSetup(): WGPUSetupResult {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return { canvasRef, runtime, resources };
+  // Resize the drawing buffer and reconfigure the surface whenever the view's
+  // layout changes (most notably device rotation). Without this the buffer keeps
+  // its original dimensions and the shader renders stretched / wrong-aspect. The
+  // render loop reads `canvas.width/height` each frame, so the resolution uniform
+  // picks up the new size on the next frame. No-op until GPU resources are ready
+  // (initial sizing is handled by the setup effect above).
+  const onCanvasLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      if (!resources) {
+        return;
+      }
+      const { width, height } = event.nativeEvent.layout;
+      const dpr = PixelRatio.get();
+      const w = Math.max(1, Math.round(width * dpr));
+      const h = Math.max(1, Math.round(height * dpr));
+
+      const prev = configuredSizeRef.current;
+      if (prev && prev.width === w && prev.height === h) {
+        return;
+      }
+
+      const canvas = resources.context.canvas as CanvasWithSize;
+      canvas.width = w;
+      canvas.height = h;
+      resources.context.configure({
+        device: resources.device,
+        format: resources.presentationFormat,
+        alphaMode: 'premultiplied',
+      });
+      configuredSizeRef.current = { width: w, height: h };
+    },
+    [resources]
+  );
+
+  return { canvasRef, runtime, resources, onCanvasLayout };
 }


### PR DESCRIPTION
## What
Medium-severity fix from the worklets/WebGPU audit: **no resize / rotation handling**.

The drawing buffer was sized and `context.configure` called exactly **once** at setup. After a rotation or any layout change, the buffer kept its original dimensions → the shader rendered stretched / wrong-aspect.

## Change
- `useWGPUSetup` now exposes `onCanvasLayout`, wired to `<Canvas onLayout>` in `ShaderView` (composed with any consumer-provided `onLayout`).
- On layout change it recomputes the physical-pixel size (`layoutSize * PixelRatio.get()`), updates `canvas.width/height`, and reconfigures the surface — but only when the size actually changed (redundant same-size passes are skipped).
- The render loop already reads `canvas.width/height` every frame, so the `resolution` uniform picks up the new size on the next frame.
- Sizes are rounded to integers for consistent pixel dimensions (initial setup rounded too, so the mount layout pass is a no-op).

## Stack
This is **PR 1 of 3** for the medium audit items, based on `fix/rn-webgpu-worklets-high-bugs` (PR #20):
1. **this** — resize/rotation
2. render-loop error/context-loss handling
3. GPU resource cleanup

## Verification
- `yarn typecheck` ✅
- `yarn lint` (changed files) ✅
- Runtime: rotation verification on device recommended (reviewer note).

## Note on cross-thread reconfigure
`configure()` runs on the JS thread while the render loop runs on the worklet runtime. Reconfigure is infrequent (rotation only) and mirrors the existing initial-configure-on-main pattern; a brief race window is possible but low-risk and is made safe once the error-handling PR (next in the stack) lands.