### PR TITLE
fix(ShaderView): survive transient render failures in the worklet loop

### DIFF
--- a/src/components/ShaderView/index.tsx
+++ b/src/components/ShaderView/index.tsx
@@ -134,6 +134,7 @@ export default function ShaderView({
       const uniformData = new Float32Array(UNIFORM_FLOAT_COUNT);
       let accumulatedTime = 0;
       let lastTimestamp = 0;
+      let warned = false;
 
       function render(timestamp: number) {
         const props = propsSync.getDirty();
@@ -212,29 +213,44 @@ export default function ShaderView({
           uniformData[27] = live[3]!;
         }
 
-        device.queue.writeBuffer(uniformBuffer, 0, uniformData);
+        // GPU work can throw when the surface is transiently invalid — the app
+        // backgrounded, the view detached, or the device was lost. Swallow the
+        // failed frame so the loop survives and recovers when the surface comes
+        // back (rather than the worklet crashing or the loop dying silently).
+        try {
+          device.queue.writeBuffer(uniformBuffer, 0, uniformData);
 
-        const commandEncoder = device.createCommandEncoder();
-        const textureView = context.getCurrentTexture().createView();
-        const passEncoder = commandEncoder.beginRenderPass({
-          colorAttachments: [
-            {
-              view: textureView,
-              clearValue: transparent ? [0, 0, 0, 0] : [0, 0, 0, 1],
-              loadOp: 'clear',
-              storeOp: 'store',
-            },
-          ],
-        });
+          const commandEncoder = device.createCommandEncoder();
+          const textureView = context.getCurrentTexture().createView();
+          const passEncoder = commandEncoder.beginRenderPass({
+            colorAttachments: [
+              {
+                view: textureView,
+                clearValue: transparent ? [0, 0, 0, 0] : [0, 0, 0, 1],
+                loadOp: 'clear',
+                storeOp: 'store',
+              },
+            ],
+          });
 
-        passEncoder.setPipeline(pipeline);
-        passEncoder.setBindGroup(0, bindGroup);
-        passEncoder.draw(3);
-        passEncoder.end();
+          passEncoder.setPipeline(pipeline);
+          passEncoder.setBindGroup(0, bindGroup);
+          passEncoder.draw(3);
+          passEncoder.end();
 
-        device.queue.submit([commandEncoder.finish()]);
-        context.present();
+          device.queue.submit([commandEncoder.finish()]);
+          context.present();
+        } catch (e) {
+          // Warn once to avoid spamming the console every frame on a persistent
+          // failure (e.g. a lost device).
+          if (!warned) {
+            warned = true;
+            console.warn('[react-native-effects] render frame failed:', e);
+          }
+        }
 
+        // Always reschedule animated loops, even after a caught failure, so the
+        // effect self-heals once the surface is valid again.
         if (!isStatic) {
           requestAnimationFrame(render);
         }


### PR DESCRIPTION
## What
Medium-severity fix from the worklets/WebGPU audit: **no error / context-loss handling in the render loop**.

The per-frame GPU work had no `try/catch`. When the surface is transiently invalid — app backgrounded, view detached, device lost — `context.getCurrentTexture()` / `context.present()` can throw, which killed the rAF loop silently or crashed the worklet.

## Change
- Wrap the frame's GPU work (`writeBuffer` → `getCurrentTexture` → `submit` → `present`) in `try/catch`.
- A failed frame is swallowed; we `console.warn` **once** (guarded by a `warned` flag) to avoid spamming every frame on a persistent failure.
- Animated loops keep rescheduling even after a caught failure, so the effect **self-heals** once the surface is valid again.

## Stack
**PR 2 of 3** for the medium audit items. Base: `fix/shaderview-resize` (PR #21). The next PR (GPU resource cleanup) builds on this — the `try/catch` here makes device teardown safe against an in-flight frame.

## Verification
- `yarn typecheck` ✅
- `yarn lint` (changed file) ✅
- Runtime: backgrounding/foregrounding the app to confirm self-heal recommended (reviewer note).

## Note
`isStatic` shaders remain one-shot — a failed first static frame is not retried (existing behaviour). Could be hardened separately if needed.