### PR TITLE
fix(ShaderView): release GPU resources to stop leaks

### DIFF
--- a/src/components/ShaderView/index.tsx
+++ b/src/components/ShaderView/index.tsx
@@ -135,16 +135,37 @@ export default function ShaderView({
       let accumulatedTime = 0;
       let lastTimestamp = 0;
       let warned = false;
+      let bufferDestroyed = false;
+
+      // Free this loop's uniform buffer when the loop ends (alive=0 / superseded
+      // by Fast Refresh / unmount). On a fragmentShader change the effect
+      // re-runs and schedules a fresh loop with a new buffer while the device
+      // persists, so without this the old buffer leaks every shader swap.
+      function destroyBuffer() {
+        if (bufferDestroyed) {
+          return;
+        }
+        bufferDestroyed = true;
+        try {
+          uniformBuffer.destroy();
+        } catch {
+          // The device may already have been destroyed on unmount — the buffer
+          // is gone either way, so there's nothing to recover.
+          return;
+        }
+      }
 
       function render(timestamp: number) {
         const props = propsSync.getDirty();
         if (props[IDX_ALIVE] === 0) {
+          destroyBuffer();
           return;
         }
 
         // This loop was superseded (Fast Refresh / unmount) — bail without
         // scheduling another frame so it can be garbage-collected.
         if (cancelled.getDirty()[0] === 1) {
+          destroyBuffer();
           return;
         }
 

--- a/src/hooks/useWGPUSetup.tsx
+++ b/src/hooks/useWGPUSetup.tsx
@@ -5,7 +5,7 @@ import {
   type RNCanvasContext,
 } from 'react-native-webgpu';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { WorkletRuntime } from 'react-native-worklets';
+import { scheduleOnRuntime, type WorkletRuntime } from 'react-native-worklets';
 import { BackgroundRuntime } from '../utils/backgroundRuntime';
 
 type GPUResources = {
@@ -38,6 +38,8 @@ export function useWGPUSetup(): WGPUSetupResult {
   const configuredSizeRef = useRef<{ width: number; height: number } | null>(
     null
   );
+  // Kept so the device can be released on unmount.
+  const deviceRef = useRef<GPUDevice | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -50,8 +52,12 @@ export function useWGPUSetup(): WGPUSetupResult {
 
       const device = await adapter.requestDevice();
       if (cancelled) {
+        // Unmounted mid-init: the worklet never used this device, so it's safe
+        // to drop it right here on the JS thread.
+        device.destroy();
         return;
       }
+      deviceRef.current = device;
 
       const context = canvasRef.current!.getContext('webgpu')!;
       const canvas = context.canvas as CanvasWithSize;
@@ -76,6 +82,19 @@ export function useWGPUSetup(): WGPUSetupResult {
 
     return () => {
       cancelled = true;
+      const device = deviceRef.current;
+      deviceRef.current = null;
+      if (device) {
+        // Release the device (and all GPU resources created from it: pipeline,
+        // buffers, ...) on the render runtime — the thread that used it — after
+        // the render loop has been signalled to stop, so we don't race an
+        // in-flight frame. Any frame that does slip through hits a destroyed
+        // device and is swallowed by the render loop's try/catch.
+        scheduleOnRuntime(runtime, () => {
+          'worklet';
+          device.destroy();
+        });
+      }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);


### PR DESCRIPTION
## What
Medium-severity fix from the worklets/WebGPU audit: **GPU resources leak**.

Two leaks addressed:

### 1. `GPUDevice` never destroyed on unmount
One device leaked per mounted `ShaderView`. `useWGPUSetup` now destroys it on unmount, **scheduled on the render runtime** (the thread that actually used the device) after the render loop has been signalled to stop — so it can't race an in-flight frame. Any frame that still slips through hits a destroyed device and is swallowed by the render loop's `try/catch` (PR #22). A device created during an unmount-mid-init is dropped directly on the JS thread (the worklet never touched it).

### 2. Per-loop uniform buffer never freed
The uniform buffer leaked on every loop teardown — most notably on each `fragmentShader` swap, where the render effect re-runs and schedules a fresh loop (new pipeline + buffer) while the device persists. The loop now calls `uniformBuffer.destroy()` when it ends (guarded against double-free and against the device already being gone).

## Stack
**PR 3 of 3** for the medium audit items. Base: `fix/shaderview-render-error-handling` (PR #22). It deliberately builds on the error-handling PR: the `try/catch` there is what makes destroying the device safe against an in-flight frame.

## Verification
- `yarn typecheck` ✅
- `yarn lint` (changed files) ✅
- Runtime: mount/unmount churn + repeated shader swaps while watching GPU memory recommended (reviewer note).

## Known remaining
A `isStatic` shader whose deps change (effect re-runs without unmount) leaks its one-shot buffer until the device is destroyed at unmount — the loop doesn't run again to hit the teardown path. Rare; noted for a follow-up if it matters.